### PR TITLE
feat(auth): add forgot/reset password UI + API with fallbacks

### DIFF
--- a/src/assets/styles/admin-login.css
+++ b/src/assets/styles/admin-login.css
@@ -134,6 +134,28 @@
   text-decoration: underline;
 }
 
+/* Style pour bouton lien dans le footer (Mot de passe oublié ?) */
+.admin-login-footer .link-like {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.admin-login-footer .link-like:hover {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
+/* Backdrop modal basique, neutralise overflow */
+.modal-backdrop {
+  overflow: auto;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(-20px); }
   to { opacity: 1; transform: translateY(0); }

--- a/src/components/admin/AdminLogin.jsx
+++ b/src/components/admin/AdminLogin.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
+import ForgotPasswordModal from '../auth/ForgotPasswordModal';
 import apiService from '../../services/api.service'; // Assure-toi que ce chemin est correct
 import '../../assets/styles/admin-login.css'; // Garde ton chemin de style s'il existe et est utilisé
 
@@ -18,6 +19,7 @@ const AdminLogin = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState(''); // Pour afficher les messages d'erreur du login
   const [loading, setLoading] = useState(false); // Pour l'état de chargement du bouton
+  const [forgotOpen, setForgotOpen] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault(); // Empêche le rechargement de la page par le formulaire
@@ -103,9 +105,18 @@ const AdminLogin = () => {
           {/* Lien pour retourner à la page d'accueil publique */}
           <a href="/">{t('footer.nav_home', "Retour à l'accueil")}</a>
           <span className="footer-separator">|</span>
-          <Link to="/forgot-password">{t('admin.forgot_password', 'Mot de passe oublié ?')}</Link>
+          <button
+            type="button"
+            className="link-like"
+            onClick={() => setForgotOpen(true)}
+            aria-haspopup="dialog"
+            aria-expanded={forgotOpen}
+          >
+            {t('admin.forgot_password', 'Mot de passe oublié ?')}
+          </button>
         </div>
       </div>
+      <ForgotPasswordModal open={forgotOpen} onClose={() => setForgotOpen(false)} />
     </div>
   );
 };

--- a/src/components/admin/ForgotPasswordPage.jsx
+++ b/src/components/admin/ForgotPasswordPage.jsx
@@ -18,15 +18,11 @@ const ForgotPasswordPage = () => {
     setMessage('');
 
     try {
-      await apiService.auth.forgotPassword(email);
-      setMessage(t('admin.forgot_password_success', 'Si un compte correspondant à cet email existe, un lien de réinitialisation a été envoyé.'));
+      await apiService.auth.postForgotPassword(email);
+      setMessage('Si cette adresse email est associée à un compte, vous recevrez un lien de réinitialisation.');
     } catch (err) {
-      // Even on error, we might not want to reveal if an email exists or not
-      // For better security, we can show the same message.
-      // However, for debugging/internal tool, showing an error might be fine.
-      setError(err.message || t('admin.forgot_password_error', 'Une erreur est survenue.'));
-      // For better security, you might want to always show the success message.
-      // setMessage(t('admin.forgot_password_success', 'Si un compte correspondant à cet email existe, un lien de réinitialisation a été envoyé.'));
+      // Sécurité: toujours succès générique
+      setMessage('Si cette adresse email est associée à un compte, vous recevrez un lien de réinitialisation.');
     } finally {
       setLoading(false);
     }
@@ -40,8 +36,7 @@ const ForgotPasswordPage = () => {
           <p>{t('admin.forgot_password_subtitle', 'Entrez votre email pour recevoir un lien de réinitialisation.')}</p>
         </div>
 
-        {message && <div className="admin-login-success" style={{ color: 'green', marginBottom: '1rem' }}>{message}</div>}
-        {error && <div className="admin-login-error" style={{ color: 'red', marginBottom: '1rem' }}>{error}</div>}
+        {message && <div aria-live="polite" className="admin-login-success" style={{ color: 'green', marginBottom: '1rem' }}>{message}</div>}
 
         {!message && (
           <form onSubmit={handleSubmit} className="admin-login-form">

--- a/src/components/admin/ResetPasswordPage.jsx
+++ b/src/components/admin/ResetPasswordPage.jsx
@@ -1,12 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import apiService from '../../services/api.service';
 import '../../assets/styles/admin-login.css'; // Re-using the login page styles
 
 const ResetPasswordPage = () => {
   const { t } = useTranslation();
   const { resettoken } = useParams();
+  const location = useLocation();
   const navigate = useNavigate();
 
   const [password, setPassword] = useState('');
@@ -14,6 +15,46 @@ const ResetPasswordPage = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [tokenValid, setTokenValid] = useState(true);
+
+  // Support token via query ?token=
+  const queryToken = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('token');
+  }, [location.search]);
+
+  const effectiveToken = queryToken || resettoken;
+
+  // Valider le token au chargement
+  useEffect(() => {
+    let isMounted = true;
+    const validate = async () => {
+      if (!effectiveToken) {
+        if (isMounted) setTokenValid(false);
+        return;
+      }
+      try {
+        const res = await apiService.auth.validateResetToken(effectiveToken);
+        if (isMounted) setTokenValid(res?.success !== false);
+      } catch (e) {
+        if (isMounted) setTokenValid(false);
+      }
+    };
+    validate();
+    return () => { isMounted = false; };
+  }, [effectiveToken]);
+
+  // Validation checklist
+  const checks = useMemo(() => {
+    const hasMin = password.length >= 8;
+    const hasUpper = /[A-Z]/.test(password);
+    const hasLower = /[a-z]/.test(password);
+    const hasDigit = /\d/.test(password);
+    const match = password.length > 0 && password === confirmPassword;
+    const score = [hasMin, hasUpper, hasLower, hasDigit].filter(Boolean).length;
+    const allOk = hasMin && hasUpper && hasLower && hasDigit && match;
+    return { hasMin, hasUpper, hasLower, hasDigit, match, score, allOk };
+  }, [password, confirmPassword]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -21,21 +62,14 @@ const ResetPasswordPage = () => {
     setError('');
     setMessage('');
 
-    if (password !== confirmPassword) {
-      setError(t('admin.passwords_do_not_match', 'Les mots de passe ne correspondent pas.'));
-      setLoading(false);
-      return;
-    }
-
-    if (password.length < 6) {
-      setError(t('admin.password_too_short', 'Le mot de passe doit contenir au moins 6 caractères.'));
+    if (!checks.allOk) {
       setLoading(false);
       return;
     }
 
     try {
-      await apiService.auth.resetPassword(resettoken, password);
-      setMessage(t('admin.reset_password_success', 'Votre mot de passe a été réinitialisé avec succès. Vous pouvez maintenant vous connecter.'));
+      await apiService.auth.postResetPassword(effectiveToken, password);
+      setMessage('Votre mot de passe a été réinitialisé avec succès ! Vous allez être redirigé vers la page de connexion.');
 
       // Redirect to login after a short delay
       setTimeout(() => {
@@ -59,7 +93,16 @@ const ResetPasswordPage = () => {
         {message && <div className="admin-login-success" style={{ color: 'green', marginBottom: '1rem' }}>{message}</div>}
         {error && <div className="admin-login-error" style={{ color: 'red', marginBottom: '1rem' }}>{error}</div>}
 
-        {!message && (
+        {!tokenValid && !message && (
+          <div className="admin-login-error" style={{ color: 'red', marginBottom: '1rem' }}>
+            Token invalide ou expiré. Veuillez demander un nouveau lien de réinitialisation.
+            <div className="admin-login-footer" style={{ marginTop: 12 }}>
+              <Link to="/admin/login">Retour à la connexion</Link>
+            </div>
+          </div>
+        )}
+
+        {!message && tokenValid && (
           <form onSubmit={handleSubmit} className="admin-login-form">
             <div className="form-group">
               <label htmlFor="password">{t('admin.new_password_label', 'Nouveau mot de passe')}</label>
@@ -85,10 +128,31 @@ const ResetPasswordPage = () => {
               />
             </div>
 
+            {/* Checklist */}
+            <ul style={{ listStyle: 'none', padding: 0, marginBottom: 12, color: '#333' }} aria-live="polite">
+              <li>{checks.hasMin ? '✅' : '⬜️'} Au moins 8 caractères</li>
+              <li>{checks.hasUpper ? '✅' : '⬜️'} 1 majuscule</li>
+              <li>{checks.hasLower ? '✅' : '⬜️'} 1 minuscule</li>
+              <li>{checks.hasDigit ? '✅' : '⬜️'} 1 chiffre</li>
+              <li>{checks.match ? '✅' : '⬜️'} Confirmation identique</li>
+            </ul>
+
+            {/* Indicateur de force 0–4 */}
+            <div style={{ display: 'flex', gap: 6, marginBottom: 16 }} aria-label="Indicateur de force du mot de passe">
+              {[0,1,2,3].map((i) => (
+                <div key={i} style={{
+                  flex: 1,
+                  height: 6,
+                  borderRadius: 3,
+                  background: i < checks.score ? 'var(--color-primary)' : '#ddd'
+                }} />
+              ))}
+            </div>
+
             <button
               type="submit"
               className={`admin-login-button ${loading ? 'loading' : ''}`}
-              disabled={loading}
+              disabled={loading || !checks.allOk}
             >
               {loading ? t('admin.resetting_password', 'Réinitialisation en cours...') : t('admin.reset_password_button', 'Réinitialiser le mot de passe')}
             </button>

--- a/src/components/auth/ForgotPasswordModal.jsx
+++ b/src/components/auth/ForgotPasswordModal.jsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import apiService from '../../services/api.service';
+import '../../assets/styles/admin-login.css';
+
+/**
+ * ForgotPasswordModal
+ * - Réutilise les styles admin-login.css
+ * - A11y: aria-modal, role dialog, focus trap, Esc pour fermer
+ * - Message de succès générique (ne révèle pas si email existe)
+ */
+const ForgotPasswordModal = ({ open, onClose }) => {
+  const dialogRef = useRef(null);
+  const firstFocusableRef = useRef(null);
+  const lastFocusableRef = useRef(null);
+
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [networkError, setNetworkError] = useState('');
+
+  const closeAndReset = useCallback(() => {
+    setEmail('');
+    setLoading(false);
+    setSubmitted(false);
+    setNetworkError('');
+    onClose?.();
+  }, [onClose]);
+
+  // Focus trap + ESC
+  useEffect(() => {
+    if (!open) return;
+
+    // Focus the first focusable element
+    const focusTimer = setTimeout(() => {
+      firstFocusableRef.current?.focus();
+    }, 0);
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        closeAndReset();
+      }
+      if (e.key === 'Tab') {
+        const focusable = dialogRef.current?.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [open, closeAndReset]);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setNetworkError('');
+    try {
+      // Toujours afficher un message de succès générique
+      await apiService.auth.postForgotPassword(email);
+      setSubmitted(true);
+    } catch (err) {
+      // Ne pas révéler l'existence de l'email
+      console.warn('forgot-password: network error (masqué en UI)');
+      setSubmitted(true);
+      // Optionnel: garder une trace locale non visible
+      setNetworkError('network');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" style={backdropStyle} aria-hidden={false}>
+      <div
+        className="admin-login-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="forgot-title"
+        aria-describedby="forgot-desc"
+        ref={dialogRef}
+        style={{ maxWidth: 480, width: '100%' }}
+      >
+        <div className="admin-login-header">
+          <h2 id="forgot-title">Réinitialiser le mot de passe</h2>
+          <p id="forgot-desc">Entrez votre adresse email pour recevoir un lien de réinitialisation.</p>
+        </div>
+
+        {!submitted && (
+          <form onSubmit={handleSubmit} className="admin-login-form">
+            <div className="form-group">
+              <label htmlFor="forgot-email">Adresse Email</label>
+              <input
+                ref={firstFocusableRef}
+                id="forgot-email"
+                name="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={loading}
+                autoComplete="email"
+              />
+            </div>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <button
+                type="button"
+                className="admin-login-button"
+                onClick={closeAndReset}
+                aria-label="Fermer la fenêtre"
+              >
+                Annuler
+              </button>
+              <button
+                ref={lastFocusableRef}
+                type="submit"
+                className={`admin-login-button ${loading ? 'loading' : ''}`}
+                disabled={loading}
+              >
+                {loading ? 'Envoi en cours...' : 'Envoyer le lien'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {submitted && (
+          <div aria-live="polite" className="admin-login-success" style={{ color: 'green', marginBottom: '1rem' }}>
+            Si cette adresse email est associée à un compte, vous recevrez un lien de réinitialisation.
+          </div>
+        )}
+
+        {submitted && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              ref={lastFocusableRef}
+              type="button"
+              className="admin-login-button"
+              onClick={closeAndReset}
+            >
+              Fermer
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const backdropStyle = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 16,
+  zIndex: 1000,
+};
+
+export default ForgotPasswordModal;


### PR DESCRIPTION
Introduce accessible ForgotPasswordModal and enhance AdminLogin to open it. Update Forgot/Reset pages with token validation, password strength checks, and safe messaging. Extend api.service with new endpoints and automatic fallback to legacy /auth routes to support both backends.